### PR TITLE
fix: Map scaling factor

### DIFF
--- a/map2gazebo/map2gazebo_offline.py
+++ b/map2gazebo/map2gazebo_offline.py
@@ -99,6 +99,7 @@ class MapConverter():
             meshes.append(mesh)
         mesh = trimesh.util.concatenate(meshes)
         mesh.update_faces(mesh.unique_faces())
+        mesh.apply_scale(1.2)
         # mesh will still have internal faces.  Would be better to get
         # all duplicate faces and remove both of them, since duplicate faces
         # are guaranteed to be internal faces


### PR DESCRIPTION
Le model SDF généré par Map2Gazebo est trop petit par rapport à la map du slam. J'ai donc ajouté un scaling factor sur le mesh de 1.2 qui semble ajuster correctement le SDF.